### PR TITLE
Add wall collisions and slowdown for snake game

### DIFF
--- a/snake.html
+++ b/snake.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Serene Snake</title>
+  <style>
+    body {
+      background: #1e1e1e;
+      color: #e0e0e0;
+      font-family: Arial, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      margin: 0;
+    }
+    h1 {
+      margin-top: 20px;
+      font-weight: normal;
+      color: #7cc6fe;
+    }
+    #game {
+      border: 2px solid #555;
+      background: #222;
+      margin-top: 20px;
+    }
+    #stats {
+      margin-top: 10px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Serene Snake</h1>
+  <canvas id="game" width="400" height="400"></canvas>
+  <div id="stats">Score: <span id="score">0</span> | Level: <span id="level">1</span></div>
+  <script>
+    const canvas = document.getElementById('game');
+    const ctx = canvas.getContext('2d');
+    const scoreEl = document.getElementById('score');
+    const levelEl = document.getElementById('level');
+
+    const cellSize = 20;
+    let gridSize = 20; // cells per row/col
+    let speed = 200; // ms per move
+    let direction = {x: 1, y: 0};
+    let snake = [{x: 10, y: 10}];
+    let foods = [];
+    let particles = [];
+    let score = 0;
+    let level = 1;
+    let interval;
+    const colors = ['#222', '#203040', '#302040', '#204030', '#402020'];
+
+    function startGame() {
+      spawnFoods();
+      render();
+      setSpeed();
+      document.addEventListener('keydown', changeDirection);
+    }
+
+    function setSpeed() {
+      clearInterval(interval);
+      interval = setInterval(update, speed);
+    }
+
+    function changeDirection(e) {
+      const key = e.key;
+      if (key === 'ArrowUp' && direction.y === 0) direction = {x: 0, y: -1};
+      else if (key === 'ArrowDown' && direction.y === 0) direction = {x: 0, y: 1};
+      else if (key === 'ArrowLeft' && direction.x === 0) direction = {x: -1, y: 0};
+      else if (key === 'ArrowRight' && direction.x === 0) direction = {x: 1, y: 0};
+    }
+
+    function spawnFoods() {
+      foods = [];
+      for (let i = 0; i < level; i++) {
+        foods.push(randomEmptyCell());
+      }
+    }
+
+    function randomEmptyCell() {
+      while (true) {
+        const cell = {
+          x: Math.floor(Math.random() * gridSize),
+          y: Math.floor(Math.random() * gridSize)
+        };
+        if (!snake.some(s => s.x === cell.x && s.y === cell.y) && !foods.some(f => f.x === cell.x && f.y === cell.y)) {
+          return cell;
+        }
+      }
+    }
+
+    function update() {
+      const head = {x: snake[0].x + direction.x, y: snake[0].y + direction.y};
+
+      // hit wall -> game over
+      if (head.x < 0 || head.y < 0 || head.x >= gridSize || head.y >= gridSize) {
+        resetGame();
+        return;
+      }
+
+      // self collision
+      if (snake.some(s => s.x === head.x && s.y === head.y)) {
+        resetGame();
+        return;
+      }
+
+      snake.unshift(head);
+
+      // check food
+      const eatenIndex = foods.findIndex(f => f.x === head.x && f.y === head.y);
+      if (eatenIndex >= 0) {
+        foods.splice(eatenIndex, 1);
+        spawnParticles(head);
+        score++;
+        scoreEl.textContent = score;
+        speed = Math.min(400, speed + 20);
+        setSpeed();
+        if (score % 5 === 0) levelUp();
+        else foods.push(randomEmptyCell());
+      } else {
+        snake.pop();
+      }
+    }
+
+    function levelUp() {
+      level++;
+      levelEl.textContent = level;
+      gridSize += 2;
+      canvas.width = canvas.height = gridSize * cellSize;
+      document.body.style.background = colors[level % colors.length];
+      spawnFoods();
+    }
+
+    function resetGame() {
+      gridSize = 20;
+      canvas.width = canvas.height = gridSize * cellSize;
+      speed = 200;
+      snake = [{x: 10, y: 10}];
+      direction = {x: 1, y: 0};
+      score = 0;
+      level = 1;
+      scoreEl.textContent = score;
+      levelEl.textContent = level;
+      document.body.style.background = '#1e1e1e';
+      spawnFoods();
+      setSpeed();
+    }
+
+    function spawnParticles(pos) {
+      for (let i = 0; i < 20; i++) {
+        particles.push({
+          x: pos.x + 0.5,
+          y: pos.y + 0.5,
+          vx: (Math.random() - 0.5) * 0.5,
+          vy: (Math.random() - 0.5) * 0.5,
+          life: 1
+        });
+      }
+    }
+
+    function render() {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      // draw snake
+      ctx.fillStyle = '#7cc6fe';
+      snake.forEach(s => {
+        ctx.fillRect(s.x * cellSize, s.y * cellSize, cellSize - 1, cellSize - 1);
+      });
+
+      // draw foods
+      ctx.fillStyle = '#ff9d76';
+      foods.forEach(f => {
+        ctx.fillRect(f.x * cellSize, f.y * cellSize, cellSize - 1, cellSize - 1);
+      });
+
+      // draw particles
+      particles.forEach(p => {
+        p.x += p.vx;
+        p.y += p.vy;
+        p.life -= 0.02;
+        ctx.globalAlpha = p.life;
+        ctx.fillStyle = '#ffeaa7';
+        ctx.fillRect(p.x * cellSize, p.y * cellSize, 2, 2);
+      });
+      ctx.globalAlpha = 1;
+      particles = particles.filter(p => p.life > 0);
+
+      requestAnimationFrame(render);
+    }
+
+    startGame();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Stop snake when hitting canvas borders, ending the game
- Slow movement speed after each food, based on amount eaten
- Clean up level logic so speed always decreases as snake grows

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689d92665124832c967433bfd5ec7bfb